### PR TITLE
Extended initializer of NetworkFetcher in order to allow providing a …

### DIFF
--- a/Haneke/NetworkFetcher.swift
+++ b/Haneke/NetworkFetcher.swift
@@ -26,11 +26,11 @@ extension HanekeGlobals {
 public class NetworkFetcher<T : DataConvertible> : Fetcher<T> {
     
     let URL : NSURL
-    
-    public init(URL : NSURL) {
+  
+    public init(URL : NSURL, key : String? = nil) {
         self.URL = URL
 
-        let key =  URL.absoluteString
+        let key = key ?? URL.absoluteString
         super.init(key: key)
     }
     


### PR DESCRIPTION
…custom key, instead of the string representation of the URL.